### PR TITLE
Replace Flickr with Fotos

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
 
                             <a href="https://www.flickr.com/search/?text=Critical%20Mass%20Hamburg" class="btn btn-secondary">
                                 <i class="fa fa-flickr" aria-hidden="true"></i>
-                                Flickr
+                                Fotos
                             </a>
                         </div>
                     </div>


### PR DESCRIPTION
The button for the videos reads "Videos" and has a YouTube icon, but the icon for the photos reads "Flickr" with the Flickr icon.

Replace the photo button text.