### PR TITLE
Change links to GitHub with criticalmass-hamburg/website

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         <meta name="twitter:image" content="https://criticalmass.hamburg/img/opengraph/preview.jpg" />
     </head>
     <body>
-        <a href="https://github.com/maltehuebner/criticalmass-hamburg">
+        <a href="https://github.com/criticalmass-hamburg/website">
             <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" />
         </a>
 
@@ -196,7 +196,7 @@
 
                     <div class="text-xs-center mt-2">
                         <div class="btn-group">
-                            <a href="https://github.com/maltehuebner/criticalmass-hamburg" class="btn btn-secondary">
+                            <a href="https://github.com/criticalmass-hamburg/website" class="btn btn-secondary">
                                 <i class="fa fa-github" aria-hidden="true"></i>
                                 GitHub
                             </a>


### PR DESCRIPTION
As the repository is now housed by criticalmass-hamburg, the repository location changed. This commit changed both links pointing to GitHub.