### PR TITLE
Added user to deploy from

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -22,6 +22,9 @@ $deployer = new Deployer([
         '192.168.0.2/24'
     ],
 
+    // User to run the script as
+    'deployUser' => 'cmhh',
+
     // Git branch to reset to
     'branch' => 'master',
 


### PR DESCRIPTION
There had to be the user `cmhh` to be specified in the deploy.php script to avoid problems with access rights.