### PR TITLE
Add travis badge for current build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/criticalmass-hamburg/website.svg?branch=master)](https://travis-ci.org/criticalmass-hamburg/website)
+
 # criticalmass.hamburg
 
 Dieses Repository beinhaltet den Quellcode der Webseite [criticalmass.hamburg](http://criticalmass.hamburg/). Bitte zögere nicht, dich mit Änderungen und Verbesserungsvorschlägen zu beteiligen.


### PR DESCRIPTION
Just include this simple piece of picture to show if travis could build our repository stuff.