### PR TITLE
Remove all foreign links

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,15 @@
             </div>
 
             <div class="row">
+                <div class="col-md-12">
+                    <div class="alert alert-danger">
+                        <strong>Sorry!</strong>
+                        Aufgrund der aktuellen Rechtsprechung können wir dir leider keine direkten Verlinkungen zu anderen Webseiten anbieten. Bitte recherchiere über eine Suchmaschine deines Vertrauens oder in den einschlägigen sozialen Netzwerken nach weiteren Informationen.
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
                 <div class="col-md-6 col-lg-4 mt-3" style="height: 200px;">
                     <h3 class="text-xs-center">
                         Folgen?

--- a/index.html
+++ b/index.html
@@ -86,11 +86,11 @@
 
                     <div class="text-xs-center mt-2">
                         <div class="btn-group">
-                            <a href="https://facebook.com/criticalmasshamburg" class="btn btn-secondary">
+                            <a href="https://facebook.com/criticalmasshamburg" class="btn btn-secondary disabled">
                                 <i class="fa fa-facebook" aria-hidden="true"></i>
                                 facebook
                             </a>
-                            <a href="https://twitter.com/cm_hh" class="btn btn-secondary">
+                            <a href="https://twitter.com/cm_hh" class="btn btn-secondary disabled">
                                 <i class="fa fa-twitter" aria-hidden="true"></i>
                                 twitter
                             </a>
@@ -123,11 +123,11 @@
 
                     <div class="text-xs-center mt-2">
                         <div class="btn-group">
-                            <a href="https://www.facebook.com/groups/CMHH.Diskussion/" class="btn btn-secondary">
+                            <a href="https://www.facebook.com/groups/CMHH.Diskussion/" class="btn btn-secondary disabled">
                                 <i class="fa fa-facebook" aria-hidden="true"></i>
                                 Diskussionsgruppe
                             </a>
-                            <a href="https://twitter.com/hashtag/cmhh,cm_hh" class="btn btn-secondary">
+                            <a href="https://twitter.com/hashtag/cmhh,cm_hh" class="btn btn-secondary disabled">
                                 <i class="fa fa-twitter" aria-hidden="true"></i>
                                 #cmhh
                             </a>
@@ -146,12 +146,12 @@
 
                     <div class="text-xs-center mt-2">
                         <div class="btn-group">
-                            <a href="https://www.youtube.com/results?search_query=Critical+Mass+Hamburg" class="btn btn-secondary">
+                            <a href="https://www.youtube.com/results?search_query=Critical+Mass+Hamburg" class="btn btn-secondary disabled">
                                 <i class="fa fa-youtube" aria-hidden="true"></i>
                                 Videos
                             </a>
 
-                            <a href="https://www.flickr.com/search/?text=Critical%20Mass%20Hamburg" class="btn btn-secondary">
+                            <a href="https://www.flickr.com/search/?text=Critical%20Mass%20Hamburg" class="btn btn-secondary disabled">
                                 <i class="fa fa-flickr" aria-hidden="true"></i>
                                 Fotos
                             </a>
@@ -170,15 +170,15 @@
 
                     <div class="text-xs-center mt-2">
                         <div class="btn-group">
-                            <a href="http://criticalmaps.net/" class="btn btn-secondary">
+                            <a href="http://criticalmaps.net/" class="btn btn-secondary disabled">
                                 Critical Maps
                             </a>
 
-                            <a href="https://itunes.apple.com/de/app/critical-mass-berlin/id918669647" class="btn btn-secondary">
+                            <a href="https://itunes.apple.com/de/app/critical-mass-berlin/id918669647" class="btn btn-secondary disabled">
                                 <i class="fa fa-apple" aria-hidden="true"></i>
                             </a>
 
-                            <a href="https://play.google.com/store/apps/details?id=de.stephanlindauer.criticalmaps" class="btn btn-secondary">
+                            <a href="https://play.google.com/store/apps/details?id=de.stephanlindauer.criticalmaps" class="btn btn-secondary disabled">
                                 <i class="fa fa-android" aria-hidden="true"></i>
                             </a>
                         </div>


### PR DESCRIPTION
Aufgrund der aktuellen Rechtsprechung des LG Hamburg, Az. C-160/15, kann es erforderlich sein, alle Verlinkungen zu fremden Webseiten zu unterbinden.

Im einzelnen sind folgende Links betroffen:

* facebook und twitter im Bereich „Folgen“: Es kann nicht sichergestellt werden, dass auf der facebook-Seite der Critical Mass Hamburg und auf deren twitter-Konto keine urheberrechtlich geschützten Medien angeboten werden. Die facebook-Seite der Critical Mass Hamburg verwendet beispielsweise ohne Genehmigung eines meiner Fotos als Header-Bild, es ist auch nicht auszuschließen, dass andere facebook-Nutzer Urheberrechtsverstöße begehen, indem sie fremde Fotos an die Pinnwand der Seite posten.
* facebook und twitter im Bereich „Mitgestalten“: Es ist ganz offensichtlich, dass in der inoffiziellen Diskussionsgruppe der Critical Mass Hamburg gegen das Urheberrecht verstoßen wird, sei es unabsichtlich über die „Teilen“-Funktion von facebook oder billigend in Kauf genommen über das Hochladen fremder Fotos, Videos oder Texte. Genausowenig kann sichergestellt werden, dass auf twitter unter dem Hashtag „#cmhh“ keine urheberrechtlich problematischen Werke geteilt werden — da sich die dort aufgelisteten Tweets regelmäßig ändern ist eine Kontrolle für mich als Seitenbetreiber überhaupt nicht möglich.
* YouTube und flicker im Bereich „Anschauen“: Hier kann ich als Seitenbetreiber ganz offensichtlich nicht sicherstellen, dass keine Verstöße gegen das Urheberrecht begangen werden.
* Critical Maps, Apple und Android im Bereich „Hinterherfahren“: Auf der Webseite „Critical Maps“ können Nutzer offenbar Fotos von Touren hochladen, womit potenziell Urheberrechtsverstöße möglich sind. Gleiches gilt für die Links auf die entsprechenden App-Stores von Apple und Android, wo mir keine Kontrolle der urheberrechtlichen Situation möglich ist.

Dieser Pull-Request wird erst einmal für den Ernstfall vorgehalten. Es ist total witzlos, einerseits eine Webseite für die Critical Mass Hamburg zu basteln, andererseits nach nicht einmal einer Woche alles wieder herunterzureißen aufgrund der aktuellen Rechtsprechung.